### PR TITLE
Add parking availability map web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Buscador de Parking Libre</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-sA+e2uoZ1CtdgMj5n2R6jVMu9zzTtmI1Y6LkZgP0h7E="
+      crossorigin=""
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Buscador de aparcamientos libres</h1>
+      <p>Selecciona una ciudad para ver los parkings públicos y privados con plazas disponibles.</p>
+    </header>
+
+    <main>
+      <section class="controls">
+        <label for="citySelect">Ciudad</label>
+        <select id="citySelect"></select>
+
+        <fieldset class="filters">
+          <legend>Tipo de parking</legend>
+          <label>
+            <input type="checkbox" id="filterPublic" checked />
+            Público
+          </label>
+          <label>
+            <input type="checkbox" id="filterPrivate" checked />
+            Privado
+          </label>
+        </fieldset>
+
+        <div class="summary" id="summary"></div>
+      </section>
+
+      <section id="map"></section>
+
+      <section class="parking-list" id="parkingList"></section>
+    </main>
+
+    <footer>
+      <small>
+        Datos ficticios con fines demostrativos. Mapa proporcionado por
+        <a href="https://www.openstreetmap.org/" target="_blank" rel="noopener">OpenStreetMap</a>
+        y <a href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>.
+      </small>
+    </footer>
+
+    <script
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-o9N1j7kGEXG6B5G2lY8U24mEY4vWwqcT9A+4JbPkz0A="
+      crossorigin=""
+    ></script>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,335 @@
+const parkingData = {
+  Madrid: {
+    center: [40.4168, -3.7038],
+    zoom: 12,
+    parkings: [
+      {
+        id: "mad-1",
+        name: "Parking Público Plaza Mayor",
+        address: "Calle de la Sal, 4",
+        type: "public",
+        totalSpaces: 320,
+        available: 58,
+        pricePerHour: 0,
+        coordinates: [40.4154, -3.7074],
+      },
+      {
+        id: "mad-2",
+        name: "Garaje Privado San Miguel",
+        address: "Calle Conde de Miranda, 3",
+        type: "private",
+        totalSpaces: 90,
+        available: 12,
+        pricePerHour: 3.5,
+        coordinates: [40.4159, -3.7089],
+      },
+      {
+        id: "mad-3",
+        name: "Parking Público Atocha",
+        address: "Glorieta del Emperador Carlos V",
+        type: "public",
+        totalSpaces: 600,
+        available: 102,
+        pricePerHour: 0,
+        coordinates: [40.4077, -3.6919],
+      },
+      {
+        id: "mad-4",
+        name: "Parking Privado Gran Vía",
+        address: "Calle de Tudescos, 1",
+        type: "private",
+        totalSpaces: 220,
+        available: 0,
+        pricePerHour: 4.2,
+        coordinates: [40.4203, -3.7058],
+      },
+      {
+        id: "mad-5",
+        name: "Parking Público Parque del Retiro",
+        address: "Avenida de Menéndez Pelayo, 67",
+        type: "public",
+        totalSpaces: 180,
+        available: 34,
+        pricePerHour: 0,
+        coordinates: [40.4152, -3.6826],
+      },
+    ],
+  },
+  Barcelona: {
+    center: [41.3851, 2.1734],
+    zoom: 12,
+    parkings: [
+      {
+        id: "bcn-1",
+        name: "Parking Público Ciutat Vella",
+        address: "Carrer de la Princesa, 19",
+        type: "public",
+        totalSpaces: 260,
+        available: 65,
+        pricePerHour: 0,
+        coordinates: [41.3854, 2.182],
+      },
+      {
+        id: "bcn-2",
+        name: "Parking Privado Passeig de Gràcia",
+        address: "Passeig de Gràcia, 74",
+        type: "private",
+        totalSpaces: 150,
+        available: 21,
+        pricePerHour: 4.8,
+        coordinates: [41.3921, 2.1645],
+      },
+      {
+        id: "bcn-3",
+        name: "Parking Público Sagrada Família",
+        address: "Carrer de Provença, 463",
+        type: "public",
+        totalSpaces: 280,
+        available: 48,
+        pricePerHour: 0,
+        coordinates: [41.4036, 2.1744],
+      },
+      {
+        id: "bcn-4",
+        name: "Parking Privado Maremagnum",
+        address: "Moll d'Espanya",
+        type: "private",
+        totalSpaces: 200,
+        available: 5,
+        pricePerHour: 5.5,
+        coordinates: [41.3753, 2.1825],
+      },
+      {
+        id: "bcn-5",
+        name: "Parking Público Montjuïc",
+        address: "Avinguda de l'Estadi, 22",
+        type: "public",
+        totalSpaces: 180,
+        available: 0,
+        pricePerHour: 0,
+        coordinates: [41.3643, 2.1556],
+      },
+    ],
+  },
+  Valencia: {
+    center: [39.4699, -0.3763],
+    zoom: 13,
+    parkings: [
+      {
+        id: "vlc-1",
+        name: "Parking Público Ayuntamiento",
+        address: "Plaça de l'Ajuntament, 1",
+        type: "public",
+        totalSpaces: 210,
+        available: 37,
+        pricePerHour: 0,
+        coordinates: [39.469, -0.3779],
+      },
+      {
+        id: "vlc-2",
+        name: "Parking Privado Ruzafa",
+        address: "Carrer de Cadis, 70",
+        type: "private",
+        totalSpaces: 120,
+        available: 9,
+        pricePerHour: 3.2,
+        coordinates: [39.4638, -0.3731],
+      },
+      {
+        id: "vlc-3",
+        name: "Parking Público Ciudad de las Artes",
+        address: "Av. del Professor López Piñero, 7",
+        type: "public",
+        totalSpaces: 450,
+        available: 88,
+        pricePerHour: 0,
+        coordinates: [39.4551, -0.3529],
+      },
+      {
+        id: "vlc-4",
+        name: "Parking Privado Malvarrosa",
+        address: "Passeig Marítim, 5",
+        type: "private",
+        totalSpaces: 160,
+        available: 24,
+        pricePerHour: 2.5,
+        coordinates: [39.4796, -0.32],
+      },
+      {
+        id: "vlc-5",
+        name: "Parking Público Bioparc",
+        address: "Av. Pío Baroja, 3",
+        type: "public",
+        totalSpaces: 300,
+        available: 0,
+        pricePerHour: 0,
+        coordinates: [39.4789, -0.4134],
+      },
+    ],
+  },
+};
+
+const typeLabels = {
+  public: "Público",
+  private: "Privado",
+};
+
+let map;
+let markersLayer;
+
+document.addEventListener("DOMContentLoaded", () => {
+  const citySelect = document.getElementById("citySelect");
+  const filterPublic = document.getElementById("filterPublic");
+  const filterPrivate = document.getElementById("filterPrivate");
+
+  Object.keys(parkingData)
+    .sort((a, b) => a.localeCompare(b, "es"))
+    .forEach((cityKey) => {
+      const option = document.createElement("option");
+      option.value = cityKey;
+      option.textContent = cityKey;
+      citySelect.append(option);
+    });
+
+  map = L.map("map", {
+    zoomControl: true,
+    attributionControl: false,
+  }).setView(parkingData[citySelect.value || Object.keys(parkingData)[0]].center, 12);
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 19,
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contribuidores',
+  }).addTo(map);
+
+  markersLayer = L.layerGroup().addTo(map);
+
+  const defaultCity = citySelect.value || Object.keys(parkingData)[0];
+  citySelect.value = defaultCity;
+
+  const updateView = () => {
+    const selectedCity = citySelect.value;
+    const showPublic = filterPublic.checked;
+    const showPrivate = filterPrivate.checked;
+    renderCity(selectedCity, { showPublic, showPrivate });
+  };
+
+  citySelect.addEventListener("change", updateView);
+  filterPublic.addEventListener("change", updateView);
+  filterPrivate.addEventListener("change", updateView);
+
+  updateView();
+});
+
+function renderCity(cityKey, filters) {
+  const city = parkingData[cityKey];
+  if (!city) return;
+
+  map.setView(city.center, city.zoom);
+  markersLayer.clearLayers();
+
+  const allowedTypes = new Set();
+  if (filters.showPublic) allowedTypes.add("public");
+  if (filters.showPrivate) allowedTypes.add("private");
+
+  const availableParkings = city.parkings.filter(
+    (parking) => parking.available > 0 && allowedTypes.has(parking.type)
+  );
+
+  const totalFreeSpots = availableParkings.reduce((acc, parking) => acc + parking.available, 0);
+
+  availableParkings.forEach((parking) => {
+    const marker = L.marker(parking.coordinates, {
+      icon: createMarkerIcon(parking.type),
+    }).addTo(markersLayer);
+
+    marker.bindPopup(`
+      <strong>${parking.name}</strong><br />
+      ${parking.address}<br />
+      ${typeLabels[parking.type]} · ${parking.available} plazas libres
+    `);
+  });
+
+  updateSummary(city, availableParkings.length, totalFreeSpots, allowedTypes);
+  renderParkingList(city, allowedTypes);
+}
+
+function updateSummary(city, parkingCount, totalFreeSpots, allowedTypes) {
+  const summary = document.getElementById("summary");
+  const typesDescription = Array.from(allowedTypes)
+    .map((type) => typeLabels[type])
+    .join(" y ") || "ningún tipo";
+
+  summary.innerHTML = `
+    <strong>${parkingCount}</strong> aparcamientos con plazas libres (${typesDescription})<br />
+    <strong>${totalFreeSpots}</strong> plazas libres en total
+  `;
+}
+
+function renderParkingList(city, allowedTypes) {
+  const list = document.getElementById("parkingList");
+  list.innerHTML = "";
+
+  const title = document.createElement("h2");
+  title.textContent = "Detalle de aparcamientos";
+  list.append(title);
+
+  city.parkings
+    .filter((parking) => allowedTypes.has(parking.type))
+    .sort((a, b) => b.available - a.available)
+    .forEach((parking) => {
+      list.append(createParkingCard(parking));
+    });
+}
+
+function createParkingCard(parking) {
+  const card = document.createElement("article");
+  card.className = "parking-card";
+
+  const badge = document.createElement("span");
+  badge.className = `badge ${parking.type}${parking.available === 0 ? " full" : ""}`;
+  badge.textContent = `${typeLabels[parking.type]}${
+    parking.available === 0 ? " · Completo" : ""
+  }`;
+
+  card.innerHTML = `
+    <h3>${parking.name}</h3>
+    <div class="meta">${parking.address}</div>
+    <div class="meta">Capacidad: ${parking.totalSpaces} plazas</div>
+    <div><strong>${parking.available}</strong> plazas libres</div>
+    <div>${
+      parking.pricePerHour === 0
+        ? "Tarifa: gratuito"
+        : `Tarifa: €${parking.pricePerHour.toFixed(2)} / hora`
+    }</div>
+  `;
+
+  card.prepend(badge);
+  return card;
+}
+
+function createMarkerIcon(type) {
+  const colors = {
+    public: "#2d9c5a",
+    private: "#d46c2a",
+  };
+
+  const color = colors[type] || "#2a77d4";
+
+  return L.divIcon({
+    className: "custom-marker",
+    html: `<span style="
+      background:${color};
+      color:#fff;
+      padding:6px 10px;
+      border-radius:999px;
+      font-weight:600;
+      box-shadow:0 2px 6px rgba(0,0,0,0.35);
+      display:inline-block;">
+      ${type === "public" ? "P" : "R"}
+    </span>`,
+    iconSize: [30, 30],
+    iconAnchor: [15, 15],
+    popupAnchor: [0, -12],
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,170 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --background: #f5f5f5;
+  --surface: #ffffff;
+  --primary: #2a77d4;
+  --primary-dark: #1f5fa8;
+  --text: #1e1e1e;
+  --text-muted: #555555;
+  --border: #dcdcdc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--text);
+}
+
+header {
+  background: var(--primary);
+  color: #fff;
+  padding: 1.5rem 1rem;
+  text-align: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.8rem;
+}
+
+header p {
+  margin: 0 auto;
+  max-width: 720px;
+  line-height: 1.5;
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(280px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  align-items: start;
+}
+
+.controls,
+.parking-list {
+  background: var(--surface);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--border);
+}
+
+.controls label,
+.controls select,
+.controls fieldset {
+  display: block;
+  width: 100%;
+}
+
+.controls label {
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+}
+
+.controls select {
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+.filters {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.filters label {
+  font-weight: 400;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.summary {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+#map {
+  height: 480px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--border);
+}
+
+.parking-list h2 {
+  margin-top: 0;
+}
+
+.parking-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+  background: #fff;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.parking-card:last-child {
+  margin-bottom: 0;
+}
+
+.parking-card .meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.badge.public {
+  background: #2d9c5a;
+}
+
+.badge.private {
+  background: #d46c2a;
+}
+
+.badge.full {
+  background: #b0b0b0;
+}
+
+@media (max-width: 960px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  #map {
+    height: 360px;
+  }
+}
+
+footer {
+  text-align: center;
+  padding: 1rem 0;
+  color: var(--text-muted);
+}
+
+footer a {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- create a single-page Leaflet map that muestra los aparcamientos libres por ciudad
- añadir filtros para parkings públicos y privados, junto con resumen y listado detallado
- incorporar estilos responsivos para la interfaz de selección y el mapa

## Testing
- python -m http.server 8000 (verificación manual en el navegador)


------
https://chatgpt.com/codex/tasks/task_e_68dfc3688758832682da8baba20f25ea